### PR TITLE
Allow specifying redis password for pubsub connections

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,6 +187,7 @@ exports.redis_subscribe_pattern = function (pattern, next) {
     plugin.redis = require('redis').createClient({
         host: plugin.redisCfg.pubsub.host,
         port: plugin.redisCfg.pubsub.port,
+        password: plugin.redisCfg.pubsub.password,
     })
         .on('psubscribe', function (pattern2, count) {
             plugin.logdebug(plugin, 'psubscribed to ' + pattern2);
@@ -209,6 +210,7 @@ exports.redis_subscribe = function (connection, next) {
     connection.notes.redis = require('redis').createClient({
         host: plugin.redisCfg.pubsub.host,
         port: plugin.redisCfg.pubsub.port,
+        password: plugin.redisCfg.pubsub.password,
     })
         .on('psubscribe', function (pattern, count) {
             connection.logdebug(plugin, 'psubscribed to ' + pattern);


### PR DESCRIPTION
Currently it is not possible to use password authenticated Redis with Haraka and some redis-aware plugin (like karma) that tries to use pubsub. If the Redis server requires authentication then you end up with the following error:

```
Jul 31 09:37:11 c20-76 haraka[4023]: [CRIT] [-] [core] ReplyError: NOAUTH Authentication required.
Jul 31 09:37:11 c20-76 haraka[4023]: [CRIT] [-] [core]     at parseError (/opt/mx/node_modules/redis-parser/lib/parser.js:193:12)
Jul 31 09:37:11 c20-76 haraka[4023]: [CRIT] [-] [core]     at parseType (/opt/mx/node_modules/redis-parser/lib/parser.js:303:14)
Jul 31 09:37:11 c20-76 haraka[4023]: [NOTICE] [-] [core] Shutting down
```

It is possible to provide the password option for normal Redis connections through the *opts* configuration option but these extra options are not used with subscription config.

This pull request makes it possible to provide the password value also to pubsub settings. The change is a quick fix, you might want to consider something more elegant, like providing the opts values to pubsub settings as well etc.

The following config works with this patch:

```ini
[opts]
password = verysecret

[server]
host   = 127.0.0.1
port   = 6379
db     = 7

[pubsub]
host   = 127.0.0.1
port   = 6379
password = verysecret
```
