### PR TITLE
copy redis pass to pubsub when host/port the same

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,8 @@
 
+# 1.0.7 - 2017-07-31
+
+- apply config [opts] to pubsub settings #7
+
 # 1.0.6 - 2017-06-16
 
 - eslint 4 compat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 1.0.{build}
 
 environment:
-  nodejs_version: "4"
+  nodejs_version: "6"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/index.js
+++ b/index.js
@@ -36,7 +36,10 @@ exports.load_redis_ini = function () {
     if (!ps.host) ps.host = s.host;
     if (!ps.port) ps.port = s.port;
 
-    if (!plugin.redisCfg.opts) plugin.redisCfg.opts = {};
+    if (plugin.redisCfg.opts === undefined) plugin.redisCfg.opts = {};
+    Object.keys(plugin.redisCfg.opts).forEach(opt => {
+        if (ps[opt] === undefined) ps[opt] = plugin.redisCfg.opts[opt];
+    });
 };
 
 exports.merge_redis_ini = function () {
@@ -79,7 +82,7 @@ exports.init_redis_shared = function (next, server) {
         });
     }
     else {
-        var opts = plugin.redisCfg.opts;
+        let opts = JSON.parse(JSON.stringify(plugin.redisCfg.opts));
         opts.host = plugin.redisCfg.server.host;
         opts.port = plugin.redisCfg.server.port;
         server.notes.redis = plugin.get_redis_client(opts, nextOnce);
@@ -184,10 +187,7 @@ exports.redis_subscribe_pattern = function (pattern, next) {
         return next();
     }
 
-    plugin.redis = require('redis').createClient({
-        host: plugin.redisCfg.pubsub.host,
-        port: plugin.redisCfg.pubsub.port,
-    })
+    plugin.redis = require('redis').createClient(plugin.redisCfg.pubsub)
         .on('psubscribe', function (pattern2, count) {
             plugin.logdebug(plugin, 'psubscribed to ' + pattern2);
             next();
@@ -206,10 +206,7 @@ exports.redis_subscribe = function (connection, next) {
         return next();
     }
 
-    connection.notes.redis = require('redis').createClient({
-        host: plugin.redisCfg.pubsub.host,
-        port: plugin.redisCfg.pubsub.port,
-    })
+    connection.notes.redis = require('redis').createClient(plugin.redisCfg.pubsub)
         .on('psubscribe', function (pattern, count) {
             connection.logdebug(plugin, 'psubscribed to ' + pattern);
             next();

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "haraka-plugin-redis",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Redis plugin for Haraka & other plugins to inherit from",
   "main": "index.js",
   "directories": {
     "test": "test"
   },
   "dependencies": {
-    "redis": "^2.6.5"
+    "redis": "^2.7.1"
   },
   "devDependencies": {
     "eslint": "*",


### PR DESCRIPTION
This is an alternative to #6 

closes #6 

Changes:
- don't munge (by reference) cfg.opts
- apply opts to pubsub
- use cfg.pubsub directly (vs passing by value)