### PR TITLE
dep: redis 3 -> 4, API change to promises

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,9 +1,9 @@
 engines:
   eslint:
     enabled: true
-    channel: "eslint-3"
+    channel: "eslint-8"
     config:
-      config: ".eslintrc"
+      config: ".eslintrc.yaml"
 
 ratings:
    paths:

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -9,6 +9,9 @@ extends: [ eslint:recommended, plugin:haraka/recommended ]
 
 root: true
 
+parserOptions:
+  ecmaVersion: 2020
+
 globals:
   OK: true
   CONT: true

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on: [ push ]
 
+env:
+  CI: true
+
 jobs:
 
   ci-test:
@@ -19,9 +22,6 @@ jobs:
         os: [ ubuntu-latest ]
         node-version: [ 12, 14, 16]
       fail-fast: false
-
-    env:
-      CI: true
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        node-version: [ 12, 14, 16]
+        node-version: [ 14, 16 ]
       fail-fast: false
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: [ push ]
 
+env:
+  CI: true
+
 jobs:
 
   lint:
@@ -28,6 +31,3 @@ jobs:
 
     - name: Lint
       run: npm run lint
-
-      env:
-        CI: true

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,6 +7,7 @@ on:
       - master
 
 env:
+  CI: true
   node_version: 14
 
 jobs:

--- a/.npmignore
+++ b/.npmignore
@@ -4,8 +4,11 @@
 .gitignore
 .gitmodules
 .lgtm.yml
-appveyor.yml
+http/bower_components
+http/node_modules
 .travis.yml
+appveyor.yml
 .eslintrc.yaml
 .eslintrc.json
 codecov.yml
+.codeclimate.yml

--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,9 @@
 
 - bump redis major version 3 -> 4
 - API change, callbacks replaced by promises
+- config.ini
+    - [server] -> [socket] 
+    - opts.db -> opts.database (to match upstream)
 
 
 ### 1.0.13 - 2021-10-14

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,6 @@
 
-### 1.0.14 - 2022-03-29
+
+### 2.0.0 - 2022-03-29
 
 - bump redis major version 3 -> 4
 - API change, callbacks replaced by promises

--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,10 @@
 
+### 1.0.14 - 2022-03-29
+
+- bump redis major version 3 -> 4
+- API change, callbacks replaced by promises
+
+
 ### 1.0.13 - 2021-10-14
 
 - switch CI from Travis to GitHub Actions

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Publish & Subscribe are DB agnostic and thus have no db setting. If host and por
 ### [opts]
 
 ```ini
-; see https://www.npmjs.com/package/redis#options-object-properties
-; db=0
+; see https://github.com/redis/node-redis/blob/HEAD/docs/client-configuration.md
+; database=0
 ; password=battery-horse-staple
 ```
 
@@ -74,17 +74,16 @@ optionally with a redis db ID. All redis config options must be listed in your p
 
 ```js
 exports.register = function () {
-    const plugin = this;
-    plugin.inherits('redis');
+    this.inherits('redis');
 
-    plugin.cfg = plugin.config.get('my-plugin.ini');
+    this.cfg = this.config.get('my-plugin.ini');
 
     // populate plugin.cfg.redis with defaults from redis.ini
-    plugin.merge_redis_ini();
+    this.merge_redis_ini();
 
     // cluster aware redis connection(s)
-    plugin.register_hook('init_master', 'init_redis_plugin');
-    plugin.register_hook('init_child',  'init_redis_plugin');
+    this.register_hook('init_master', 'init_redis_plugin');
+    this.register_hook('init_child',  'init_redis_plugin');
 }
 ```
 
@@ -101,8 +100,7 @@ Notice the database ID numbers appended to each plugins redis connection
 message.
 
 
-
-[ci-img]: https://github.com/haraka/haraka-plugin-redis/workflows/Tests/badge.svg
-[ci-url]: https://github.com/haraka/haraka-plugin-redis/actions?query=workflow%3ATests
+[ci-img]: https://github.com/haraka/haraka-plugin-redis/actions/workflows/ci-test.yml/badge.svg
+[ci-url]: https://github.com/haraka/haraka-plugin-redis/actions/workflows/ci-test.yml
 [clim-img]: https://codeclimate.com/github/haraka/haraka-plugin-redis/badges/gpa.svg
 [clim-url]: https://codeclimate.com/github/haraka/haraka-plugin-redis

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ attached to another database.
 
 The `redis.ini` file has the following sections (defaults shown):
 
-### [server]
+### [socket]
 
 ```ini
 ; host=127.0.0.1
@@ -25,7 +25,7 @@ The `redis.ini` file has the following sections (defaults shown):
 ; port=6379
 ```
 
-Publish & Subscribe are DB agnostic and thus have no db setting. If host and port and not defined, they default to the same as [server] settings.
+Publish & Subscribe are DB agnostic and thus have no db setting. If host and port and not defined, they default to the same as [socket] settings.
 
 ### [opts]
 

--- a/config/redis.ini
+++ b/config/redis.ini
@@ -1,13 +1,12 @@
 
-[server]
+[socket]
 ; host=127.0.0.1
 ; port=6379
-; db=0
 
 [pubsub]
 ; host=127.0.0.1
 ; port=6379
 
 [opts]
-; db=0
+; database=0
 ; password=dontUseThisOne

--- a/index.js
+++ b/index.js
@@ -4,16 +4,14 @@
 const redis = require('redis');
 
 exports.register = function () {
-    const plugin = this;
-
-    plugin.load_redis_ini();
+    this.load_redis_ini();
 
     // another plugin has called us with: inherits('haraka-plugin-redis')
-    if (plugin.name !== 'redis') return;
+    if (this.name !== 'redis') return;
 
     // register when 'redis' is declared in config/plugins
-    plugin.register_hook('init_master', 'init_redis_shared');
-    plugin.register_hook('init_child',  'init_redis_shared');
+    this.register_hook('init_master', 'init_redis_shared');
+    this.register_hook('init_child',  'init_redis_shared');
 }
 
 const defaultOpts = { socket: { host: '127.0.0.1', port: '6379' } }
@@ -52,13 +50,12 @@ exports.load_redis_ini = function () {
 }
 
 exports.merge_redis_ini = function () {
-    const plugin = this;
 
-    if (!plugin.cfg)       plugin.cfg = {};   // no <plugin>.ini loaded?
-    if (!plugin.cfg.redis) plugin.cfg.redis = {}; // no [redis] in <plugin>.ini file
-    if (!plugin.redisCfg)  plugin.load_redis_ini();
+    if (!this.cfg)       this.cfg = {};   // no <plugin>.ini loaded?
+    if (!this.cfg.redis) this.cfg.redis = {}; // no [redis] in <plugin>.ini file
+    if (!this.redisCfg)  this.load_redis_ini();
 
-    plugin.cfg.redis = Object.assign({}, plugin.redisCfg.server, plugin.cfg.redis);
+    this.cfg.redis = Object.assign({}, this.redisCfg.server, this.cfg.redis);
 }
 
 exports.init_redis_shared = function (next, server) {
@@ -127,21 +124,20 @@ exports.shutdown = function () {
 }
 
 exports.redis_ping = async function () {
-    const plugin = this;
 
-    plugin.redis_pings=false;
+    this.redis_pings=false;
 
-    if (!plugin.db) {
+    if (!this.db) {
         return new Error('redis not initialized');
     }
 
     try {
-        const r = await plugin.db.ping()
+        const r = await this.db.ping()
         if (r !== 'PONG') return new Error('not PONG');
-        plugin.redis_pings=true
+        this.redis_pings=true
     }
     catch (e) {
-        plugin.logerror(e.message)
+        this.logerror(e.message)
     }
 }
 
@@ -194,14 +190,13 @@ exports.get_redis_sub_channel = function (conn) {
 }
 
 exports.redis_subscribe_pattern = async function (pattern) {
-    const plugin = this;
 
-    if (plugin.redis) return // already subscribed?
+    if (this.redis) return // already subscribed?
 
-    plugin.redis = await redis.createClient(plugin.redisCfg.pubsub)
+    this.redis = await redis.createClient(this.redisCfg.pubsub)
 
-    await plugin.redis.psubscribe(pattern);
-    plugin.logdebug(plugin, `psubscribed to ${pattern}`);
+    await this.redis.psubscribe(pattern);
+    this.logdebug(this, `psubscribed to ${pattern}`);
 }
 
 exports.redis_subscribe = async function (connection) {

--- a/package.json
+++ b/package.json
@@ -1,25 +1,25 @@
 {
   "name": "haraka-plugin-redis",
-  "version": "1.0.13",
+  "version": "2.0.0",
   "description": "Redis plugin for Haraka & other plugins to inherit from",
   "main": "index.js",
   "directories": {
     "test": "test"
   },
   "dependencies": {
-    "redis": "^3.1.2"
+    "redis": "^4.0.0"
   },
   "devDependencies": {
-    "eslint": ">=7",
+    "eslint": ">=8",
     "eslint-plugin-haraka": "*",
     "haraka-test-fixtures": "*",
-    "mocha": "*"
+    "mocha": "^9.0.0"
   },
   "scripts": {
     "lint": "npx eslint *.js test/*.js",
     "lintfix": "npx eslint --fix *.js test/*.js",
     "cover": "NODE_ENV=cov npx nyc --reporter=lcovonly npm run test",
-    "test": "npx mocha --exit"
+    "test": "npx mocha"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,15 +10,16 @@
     "redis": "^4.0.0"
   },
   "devDependencies": {
-    "eslint": ">=8",
+    "eslint": "^8.12.0",
     "eslint-plugin-haraka": "*",
     "haraka-test-fixtures": "*",
-    "mocha": "^9.0.0"
+    "mocha": "^9.2.0"
   },
   "scripts": {
     "lint": "npx eslint *.js test/*.js",
     "lintfix": "npx eslint --fix *.js test/*.js",
     "cover": "NODE_ENV=cov npx nyc --reporter=lcovonly npm run test",
+    "versions": "npx dependency-version-checker check",
     "test": "npx mocha"
   },
   "repository": {

--- a/test/config/redis.ini
+++ b/test/config/redis.ini
@@ -1,12 +1,13 @@
 
+[socket]
 ; host=127.0.0.1
 ; port=6379
-; db=0
+; path=/var/db/redis.sock
 
 [pubsub]
 ; host=127.0.0.1
 ; port=6379
 
 [opts]
-db=5
+database=5
 password=dontUseThisOne

--- a/test/redis.js
+++ b/test/redis.js
@@ -13,102 +13,100 @@ function retry (options) {
 }
 
 describe('config', function () {
-    before(function (done) {
+    before(async function () {
         this.plugin = new fixtures.plugin('index')
         this.plugin.register()
-        done()
     })
 
-    it('loads', function (done) {
+    it('loads', async function () {
         assert.equal(this.plugin.name, 'index');
-        done()
     })
 
-    it('config defaults', function (done) {
-        assert.equal(this.plugin.redisCfg.server.host, '127.0.0.1')
-        assert.equal(this.plugin.redisCfg.server.port, 6379)
-        done()
+    it('config defaults', async function () {
+        assert.equal(this.plugin.redisCfg.server.socket.host, '127.0.0.1')
+        assert.equal(this.plugin.redisCfg.server.socket.port, 6379)
     })
 
-    it('merges [opts] into server config', function (done) {
+    it('merges [opts] into server config', async function () {
         this.plugin.config = this.plugin.config.module_config(path.resolve('test'));
         this.plugin.load_redis_ini();
         assert.deepEqual(this.plugin.redisCfg, {
             main: {},
+            socket: {},
             pubsub: {
-                host: '127.0.0.1',
-                port: '6379',
-                db: 5,
+                socket: {
+                    host: '127.0.0.1',
+                    port: '6379',
+                },
+                database: 5,
                 password: 'dontUseThisOne'
             },
-            opts: { db: 5, password: 'dontUseThisOne' },
+            opts: { database: 5, password: 'dontUseThisOne' },
             server: {
-                host: '127.0.0.1',
-                port: '6379',
-                db: 5,
+                socket: {
+                    host: '127.0.0.1',
+                    port: '6379',
+                },
+                database: 5,
                 password: 'dontUseThisOne'
             }
         });
-        done();
     })
 
-    it('merges redis.ini [opts] into plugin config', function (done) {
+    it('merges redis.ini [opts] into plugin config', async function () {
         this.plugin.config = this.plugin.config.module_config(path.resolve('test'));
         this.plugin.load_redis_ini();
         this.plugin.cfg = {};
         this.plugin.merge_redis_ini();
         assert.deepEqual(this.plugin.cfg, {
             redis: {
-                host: '127.0.0.1',
-                port: '6379',
-                db: 5,
+                socket: {
+                    host: '127.0.0.1',
+                    port: '6379',
+                },
+                database: 5,
                 password: 'dontUseThisOne'
             }
         })
-        done()
     })
 })
 
 describe('connects', function () {
-    before(function (done) {
+    before(async function () {
         this.plugin = new fixtures.plugin('index')
         this.plugin.register()
-        done()
     })
 
-    it('loads', function (done) {
+    it('loads', async function () {
         assert.equal(this.plugin.name, 'index');
-        done();
     })
 
-    it('connects', function (done) {
-        const redis = this.plugin.get_redis_client({
-            host: this.plugin.redisCfg.server.host,
-            port: this.plugin.redisCfg.server.port,
+    it('connects', async function () {
+        const redis = await this.plugin.get_redis_client({
+            socket: {
+                host: this.plugin.redisCfg.server.host,
+                port: this.plugin.redisCfg.server.port,
+            },
             retry_strategy: retry,
-        },
-        function () {
-            assert.ok(redis.connected);
-            done();
-        });
+        })
+        assert.ok(redis);
+        redis.disconnect()
     })
 
-    it('populates plugin.cfg.redis when asked', function (done) {
+    it('populates plugin.cfg.redis when asked', async function () {
         assert.equal(this.plugin.cfg, undefined);
         this.plugin.merge_redis_ini();
-        assert.deepEqual(this.plugin.cfg.redis, { host: '127.0.0.1', port: '6379' });
-        done();
+        assert.deepEqual(this.plugin.cfg.redis, { socket: { host: '127.0.0.1', port: '6379' } });
     })
 
-    it('connects to a different redis db', function (done) {
+    it('connects to a different redis db', async function () {
         this.plugin.merge_redis_ini();
-        this.plugin.cfg.redis.db = 2;
+        this.plugin.cfg.redis.database = 2;
         this.plugin.cfg.redis.retry_strategy = retry;
-        const client = this.plugin.get_redis_client(this.plugin.cfg.redis, function () {
-            // console.log(client);
-            assert.equal(client.connected, true)
-            assert.equal(client.selected_db, 2)
-            done()
-        })
+        const client = await this.plugin.get_redis_client(this.plugin.cfg.redis)
+        const res = await client.ping()
+        assert.equal(res, 'PONG')
+        assert.ok(client)
+        await client.disconnect()
     })
 })


### PR DESCRIPTION
Changes proposed in this pull request:
- dep: redis 3 -> 4, API change to promises
- related to haraka/Haraka#3025
- config.ini
    - [server] -> [socket] 
    - opts.db -> opts.database (to match upstream)

Checklist:
- [x] docs updated
- [x] tests updated
- [x] Changes.md updated
- [x] package.json.version bumped
- [ ] published to NPM (will be done by @core)
