### PR TITLE
fix: rename p* methods -> * (required in redis v4)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,4 +9,3 @@ Checklist:
 - [ ] tests updated
 - [ ] Changes.md updated
 - [ ] package.json.version bumped
-- [ ] published to NPM (will be done by @core)

--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,11 @@
 
 
+### 2.0.1 - 2022-05-23
+
+- fix: rename p* methods -> * (required in redis v4)
+- dep(redis): bump 4.0 -> 4.1
+
+
 ### 2.0.0 - 2022-03-29
 
 - bump redis major version 3 -> 4

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 [![Build Status][ci-img]][ci-url]
 [![Code Climate][clim-img]][clim-url]
 
-Connects to a redis instance. By default it stores a `redis`
-connection handle at `server.notes.redis`. See below to get a custom DB handle
-attached to another database.
+Connects to a redis instance. By default it stores a `redis` connection handle at `server.notes.redis`. See below to get a custom DB handle attached to another database.
 
 ## Config
 

--- a/index.js
+++ b/index.js
@@ -195,11 +195,11 @@ exports.redis_subscribe_pattern = async function (pattern) {
 
     this.redis = await redis.createClient(this.redisCfg.pubsub)
 
-    await this.redis.psubscribe(pattern);
-    this.logdebug(this, `psubscribed to ${pattern}`);
+    await this.redis.subscribe(pattern);
+    this.logdebug(this, `subscribed to ${pattern}`);
 }
 
-exports.redis_subscribe = async function (connection) {
+exports.redis_subscribe = async function (connection, event) {
 
     if (connection.notes.redis) {
         connection.logdebug(this, `redis already subscribed`);
@@ -207,7 +207,7 @@ exports.redis_subscribe = async function (connection) {
     }
 
     const timer = setTimeout(() => {
-        connection.logerror('redis psubscribe timed out');
+        connection.logerror('redis subscribe timed out');
     }, 3 * 1000);
 
     connection.notes.redis = await redis.createClient(this.redisCfg.pubsub)
@@ -215,8 +215,8 @@ exports.redis_subscribe = async function (connection) {
     clearTimeout(timer);
 
     const pattern = this.get_redis_sub_channel(connection)
-    connection.notes.redis.psubscribe(pattern);
-    connection.logdebug(this, `psubscribed to ${pattern}`);
+    connection.notes.redis.subscribe(pattern, event);
+    connection.logdebug(this, `subscribed to ${pattern}`);
 }
 
 exports.redis_unsubscribe = async function (connection) {
@@ -227,7 +227,7 @@ exports.redis_unsubscribe = async function (connection) {
     }
 
     const pattern = this.get_redis_sub_channel(connection)
-    await connection.notes.redis.punsubscribe(pattern);
+    await connection.notes.redis.unsubscribe(pattern);
     connection.logdebug(this, `unsubsubscribed from ${pattern}`);
     connection.notes.redis.disconnect();
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "haraka-plugin-redis",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Redis plugin for Haraka & other plugins to inherit from",
   "main": "index.js",
   "directories": {
     "test": "test"
   },
   "dependencies": {
-    "redis": "^4.0.0"
+    "redis": "^4.1.0"
   },
   "devDependencies": {
     "eslint": "^8.12.0",


### PR DESCRIPTION
Changes proposed in this pull request:

- dep(redis): bump 4.0 -> 4.1

Checklist:
- [x] docs updated
- [ ] tests updated
- [x] Changes.md updated
- [x] package.json.version bumped