### PR TITLE
Update README.md confugartion `[socket]` -> `[server]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Connects to a redis instance. By default it stores a `redis` connection handle a
 
 The `redis.ini` file has the following sections (defaults shown):
 
-### [socket]
+### [server]
 
 ```ini
 ; host=127.0.0.1


### PR DESCRIPTION
`[socket]` is now `[server]`

Fixes #

Changes proposed in this pull request:
- Updated documentation about the configuration of theharaka-plugin-redis.
Indeed, `[socket]` must be replaced by `[server]`

Checklist:
- [X] docs updated
- [ ] tests updated
- [ ] Changes.md updated
- [ ] package.json.version bumped
