### PR TITLE
fix missing error handlers on pi-watch and pi-karma redis clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+### [2.0.8] - 2024-11-08
+
+- fix missing error handlers on pi-watch and pi-karma redis clients [#45](https://github.com/haraka/haraka-plugin-redis/issues/45)
+
 ### [2.0.7] - 2024-04-21
 
 - populate [files] in package.json. Delete .npmignore.

--- a/index.js
+++ b/index.js
@@ -216,6 +216,9 @@ exports.redis_subscribe_pattern = async function (pattern, onMessage) {
   if (this.redis) return // already subscribed?
 
   this.redis = redis.createClient(this.redisCfg.pubsub)
+  this.redis.on('error', (err) => {
+    this.logerror(err.message)
+  })
   await this.redis.connect()
 
   await this.redis.pSubscribe(pattern, onMessage)
@@ -234,6 +237,9 @@ exports.redis_subscribe = async function (connection, onMessage) {
   }, 3 * 1000)
 
   connection.notes.redis = redis.createClient(this.redisCfg.pubsub)
+  connection.notes.redis.on('error', (err) => {
+    this.logerror(err.message)
+  })
   await connection.notes.redis.connect()
 
   clearTimeout(timer)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-redis",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Redis plugin for Haraka & other plugins to inherit from",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Fixes [#45](https://github.com/haraka/haraka-plugin-redis/issues/45)

Changes proposed in this pull request:

- add error handlers on pi-watch and pi-karma redis clients

Checklist:

- [ ] docs updated
- [ ] tests updated
- [x] Changes.md updated
- [x] package.json.version bumped
