### PR TITLE
fix no client QUIT on shutdown when it is not connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### [2.0.8] - 2024-11-08
 
 - fix missing error handlers on pi-watch and pi-karma redis clients [#45](https://github.com/haraka/haraka-plugin-redis/issues/45)
+- fix no client QUIT on shutdown when it is not connected [#47]https://github.com/haraka/haraka-plugin-redis/pull/47
 
 ### [2.0.7] - 2024-04-21
 

--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ exports.init_redis_plugin = function (next, server) {
 exports.shutdown = function () {
   if (this.db) this.db.quit()
 
-  if (server && server.notes && server.notes.redis) {
+  if (server && server.notes && server.notes.redis && server.notes.redis.isOpen) {
     server.notes.redis.quit()
   }
 }


### PR DESCRIPTION
Not telling redis client to quit on shutdown when it is not connected.

Fixes the following critical error when using `graceful_shutdown=true` in smtp.ini and sending SIGINT to Haraka:

```
[NOTICE] [-] [core] SIGINT received
[INFO] [-] [server] Shutting down listeners
[INFO] [-] [server] Workers closed. Shutting down master process subsystems
[INFO] [-] [outbound] Shutting down temp fail queue
[INFO] [-] [plugins] Shutting down
[CRIT] [-] [core] Error: The client is closed
[CRIT] [-] [core]     at RedisSocket.quit (/opt/Haraka/node_modules/@redis/client/dist/lib/client/socket.js:70:19)
[CRIT] [-] [core]     at Commander.QUIT (/opt/Haraka/node_modules/@redis/client/dist/lib/client/index.js:260:71)
[CRIT] [-] [core]     at exports.shutdown (/opt/Haraka/node_modules/haraka-plugin-redis/index.js:153:24)
[CRIT] [-] [core]     at exports.shutdown_plugins (/opt/Haraka/plugins.js:240:43)
[CRIT] [-] [core]     at process.<anonymous> (/opt/Haraka/plugins.js:248:17)
[CRIT] [-] [core]     at process.emit (node:events:530:35)
[CRIT] [-] [core]     at Server._graceful (/opt/Haraka/server.js:237:21)
[CRIT] [-] [core]     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

Checklist:

- [ ] docs updated
- [ ] tests updated
- [x] Changes.md updated
- [ ] package.json.version bumped
