### PR TITLE
Fixes on redis connection handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+### [2.1.1] - 2026-06-18
+
+- fix: shutdown races with hook_disconnect causing "The client is closed"
+- fix: init_redis_shared reconnects when existing client is closed or ping fails
+- fix: init_redis_plugin checks isOpen before reusing server.notes.redis
 - dep(redis): upgrade to v6
 - test: refactored against test-fixtures 1.7.0
 
@@ -137,3 +142,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 [2.0.10]: https://github.com/haraka/haraka-plugin-redis/releases/tag/v2.0.10
 [2.0.11]: https://github.com/haraka/haraka-plugin-redis/releases/tag/v2.0.11
 [2.1.0]: https://github.com/haraka/haraka-plugin-redis/releases/tag/v2.1.0
+[2.1.1]: https://github.com/haraka/haraka-plugin-redis/releases/tag/v2.1.1

--- a/index.js
+++ b/index.js
@@ -92,18 +92,18 @@ exports.merge_redis_ini = function () {
 
 exports.init_redis_shared = async function (next, server) {
   // server-wide redis, shared by plugins that don't specify a db ID.
-  if (!server.notes.redis) {
+  if (server.notes.redis?.isOpen) {
     try {
-      server.notes.redis = await this.get_redis_client(this.redisCfg.server)
+      await server.notes.redis.ping()
+      this.loginfo('already connected')
+      return next()
     } catch (e) {
-      this.logerror(`Redis error: ${e.message}`)
+      this.logerror(`Redis ping failed, reconnecting: ${e.message}`)
     }
-    return next()
   }
 
   try {
-    await server.notes.redis.ping()
-    this.loginfo('already connected')
+    server.notes.redis = await this.get_redis_client(this.redisCfg.server)
   } catch (e) {
     this.logerror(`Redis error: ${e.message}`)
   }
@@ -123,7 +123,7 @@ exports.init_redis_plugin = async function (next, server) {
   if (!server) server = { notes: {} }
 
   const pidb = this.cfg.redis.database
-  if (server.notes.redis) {
+  if (server.notes.redis?.isOpen) {
     // server-wide redis is available
     // and the DB not specified or is the same as server-wide
     if (pidb === undefined || pidb === this.redisCfg.server.database) {
@@ -142,15 +142,12 @@ exports.init_redis_plugin = async function (next, server) {
 }
 
 exports.shutdown = function () {
-  if (this.db) this.db.quit()
-
-  if (
-    server &&
-    server.notes &&
-    server.notes.redis &&
-    server.notes.redis.isOpen
-  ) {
-    server.notes.redis.quit()
+  // Only quit a plugin-private connection. server.notes.redis must stay open
+  // until all per-connection hooks (hook_disconnect, etc.) have finished —
+  // calling quit() here races with those in-flight operations and causes
+  // "The client is closed" errors. The socket is released when the process exits.
+  if (this.db?.isOpen && this.db !== server?.notes?.redis) {
+    this.db.quit()
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-redis",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Redis plugin for Haraka & other plugins to inherit from",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
- fix: shutdown races with hook_disconnect causing "The client is closed"
- fix: init_redis_shared reconnects when existing client is closed or ping fails
- fix: init_redis_plugin checks isOpen before reusing server.notes.redis

Should fix these kinds of errors on Haraka restart:

```
[CRIT] [-] [core] Error: The client is closed
[CRIT] [-] [core]     at /path/to/Haraka/node_modules/haraka-plugin-redis/node_modules/@redis/client/dist/lib/client/index.js:749:39
[CRIT] [-] [core]     at trace (/path/to/Haraka/node_modules/haraka-plugin-redis/node_modules/@redis/client/dist/lib/client/tracing.js:94:12)
[CRIT] [-] [core]     at Class.sendCommand (/path/to/Haraka/node_modules/haraka-plugin-redis/node_modules/@redis/client/dist/lib/client/index.js:747:36)
[CRIT] [-] [core]     at fn (/path/to/Haraka/node_modules/haraka-plugin-redis/node_modules/@redis/client/dist/lib/client/index.js:715:40)
[CRIT] [-] [core]     at Class._executeCommand (/path/to/Haraka/node_modules/haraka-plugin-redis/node_modules/@redis/client/dist/lib/client/index.js:720:33)
[CRIT] [-] [core]     at Class.hIncrBy (/path/to/Haraka/node_modules/haraka-plugin-redis/node_modules/@redis/client/dist/lib/client/index.js:60:31)
[CRIT] [-] [core]     at exports.increment (/path/to/Haraka/node_modules/haraka-plugin-karma/index.js:738:23)
[CRIT] [-] [core]     at exports.hook_disconnect (/path/to/Haraka/node_modules/haraka-plugin-karma/index.js:762:10)
[CRIT] [-] [core]     at plugins.run_next_hook (/path/to/Haraka/plugins.js:511:26)
[CRIT] [-] [core]     at callback (/path/to/Haraka/plugins.js:467:32)
```

Claude analysis:

> Root cause
> 
> During a graceful restart, Haraka calls each plugin's shutdown() hook while existing SMTP connections are still being torn down. The original shutdown() called quit() on server.notes.redis, which synchronously marks the client as "closing" — any command issued after that point is immediately rejected with The client is closed.
> 
> This races with per-connection hooks that are still running. haraka-plugin-karma's hook_disconnect, for example, calls hIncrBy() on the shared client as each connection closes. By the time those callbacks fire, the client is already closing, so they fail. The failing callbacks prevent connections from cleaning up, which prevents workers from exiting gracefully, which is why they end up being forcibly killed.
> 
> The fixes
> 
> shutdown() no longer calls quit() on server.notes.redis. The shared connection has to outlive the shutdown hook, because per-connection hooks depend on it. Plugin-private connections (where this.db !== server.notes.redis) are still closed, since only that one plugin uses them. The shared socket is released when the process exits — Redis handles the disconnect gracefully.
> 
> init_redis_shared() now reconnects whenever the existing client is absent, closed, or fails a ping, instead of logging an error and continuing with a broken connection.
> 
> init_redis_plugin() adds an isOpen guard before reusing server.notes.redis, so a closed shared client doesn't get handed to a plugin as if it were healthy.

Checklist:

- [ ] docs updated
- [ ] tests updated
- [x] Changes.md updated
- [x] package.json.version bumped
